### PR TITLE
Setting kindr_FOUND to true

### DIFF
--- a/kindrConfig.cmake.in
+++ b/kindrConfig.cmake.in
@@ -8,3 +8,4 @@ set(kindr_INCLUDE_DIRS "@kindr_include_dirs@")
 
 # This causes catkin_simple to link against these libraries
 set(kindr_FOUND_CATKIN_PROJECT true)
+set(kindr_FOUND true)


### PR DESCRIPTION
This is to prevent catkin from detecting the file but setting it as NOT FOUND (see https://github.com/ethz-asl/kindr_ros/issues/16)